### PR TITLE
Add missing 'use' statements for argument types

### DIFF
--- a/src/Magento/Command/AbstractCommand.php
+++ b/src/Magento/Command/AbstractCommand.php
@@ -3,6 +3,8 @@
 namespace TiB\PatchPal\Magento\Command;
 
 use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractCommand extends AbstractMagentoCommand
 {


### PR DESCRIPTION
This fixes two warnings on startup

> PHP Warning:  Declaration of TiB\PatchPal\Magento\Command\AbstractCommand::execute(TiB\PatchPal\Magento\Command\InputInterface $input, TiB\PatchPal\Magento\Command\OutputInterface $output) should be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) in /[...]/.modman/pocallaghan_magerun-patchpal/src/Magento/Command/AbstractCommand.php on line 121

> PHP Warning:  Declaration of TiB\PatchPal\Magento\Command\CompatCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) should be compatible with TiB\PatchPal\Magento\Command\AbstractCommand::execute(TiB\PatchPal\Magento\Command\InputInterface $input, TiB\PatchPal\Magento\Command\OutputInterface $output) in /[...]/.modman/pocallaghan_magerun-patchpal/src/Magento/Command/CompatCommand.php on line 12


as well as a fatal error

> PHP Fatal error:  Uncaught TypeError: Argument 1 passed to TiB\PatchPal\Magento\Command\AbstractCommand::validateChangesetSource() must be an instance of TiB\PatchPal\Magento\Command\InputInterface, instance of Symfony\Component\Console\Input\ArgvInput given, called in /[...]/.modman/pocallaghan_magerun-patchpal/src/Magento/Command/CompatCommand.php on line 32 and defined in /[...]/.modman/pocallaghan_magerun-patchpal/src/Magento/Command/AbstractCommand.php:45

(with PHP 7.1 and Symfony console 3.4.11)