### PR TITLE
Fix missing use statements in abstract command

### DIFF
--- a/src/Magento/Command/AbstractCommand.php
+++ b/src/Magento/Command/AbstractCommand.php
@@ -2,6 +2,8 @@
 
 namespace TiB\PatchPal\Magento\Command;
 
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use N98\Magento\Command\AbstractMagentoCommand;
 
 abstract class AbstractCommand extends AbstractMagentoCommand


### PR DESCRIPTION
Running `patch:compat:all` gives the following error:
```
PHP Strict standards:  Declaration of TiB\PatchPal\Magento\Command\CompatCommand::execute() should be compatible with TiB\PatchPal\Magento\Command\AbstractCommand::execute(TiB\PatchPal\Magento\Command\InputInterface $input, TiB\PatchPal\Magento\Command\OutputInterface $output) in /home/vagrant/.n98-magerun/modules/magerun-patchpal/src/Magento/Command/CompatCommand.php on line 13
```

Looks like there are two missing use statements in the `AbstractCommand` class that are in `CompatCommand` which causes the type declarations for the `execute` method arguments to be different between the two classes